### PR TITLE
Trying to fix out of bounds exception

### DIFF
--- a/src/main/java/eu/verdelhan/ansluta/AnslutaRemote.java
+++ b/src/main/java/eu/verdelhan/ansluta/AnslutaRemote.java
@@ -89,7 +89,7 @@ public class AnslutaRemote {
 
                 if (PacketLength <= 8) { // A packet from the remote cant be longer than 8 bytes
                     // Read the received data from CC2500
-                    for (byte i = 1; i <= PacketLength; i++) {
+                    for (byte i = 0; i < PacketLength; i++) {
                         recvPacket[i] = readRegister(CC2500.CC2500_FIFO);
                     }
                     if (DEBUG) {


### PR DESCRIPTION
Not sure why you start with 1 here as i did not check all your code yet, but this should at least stop the out of bounds exception. Did not test it yet as i do not have my raspi setup yet. However when packetlength was 0 you still start with 1 which causes the out of bounds exception.

Also from what i can see you start to write in the array with index 1 but you only create the array the exact same size the packetlength is. So even if the packlength is not 0 it will give you an error. Example:
packetlength 5
array.length = 5
array[0] = undefined
array{1] = 1st element
array[2] = 2nd element
...
array{4] = 4th element
The 5th element can not be stored as it is out of bounds already.